### PR TITLE
This feature allows you to pass through additional properties on the nodes

### DIFF
--- a/dag-store.js
+++ b/dag-store.js
@@ -4,10 +4,10 @@ import uuid from 'node-uuid';
 let nodes = (state = [], action = {}) => {
   switch(action.type) {
     case 'ADD-NODE':
-      let v = Object.assign({}, action.payload, { id: uuid.v4() }); 
+      let nodeProps = Object.assign({}, action.payload, { id: uuid.v4() }); 
       return [
         ...state,
-        v
+        nodeProps
       ];
     case 'UPDATE_NODE':
       return state.map(node => {

--- a/dag-store.js
+++ b/dag-store.js
@@ -4,13 +4,9 @@ import uuid from 'node-uuid';
 let nodes = (state = [], action = {}) => {
   switch(action.type) {
     case 'ADD-NODE':
-      return [
-        ...state,
-        {
-          id: uuid.v4(),
-          label: action.payload.label,
-          type: action.payload.type
-        }
+	return [
+     	      ...state,
+              Object.assign({}, { id: uuid.v4() }, action.paylod) 
       ];
     case 'UPDATE_NODE':
       return state.map(node => {

--- a/dag-store.js
+++ b/dag-store.js
@@ -4,9 +4,10 @@ import uuid from 'node-uuid';
 let nodes = (state = [], action = {}) => {
   switch(action.type) {
     case 'ADD-NODE':
+      let v = Object.assign({}, action.payload, { id: uuid.v4() }); 
       return [
         ...state,
-        Object.assign({}, { id: uuid.v4() }, action.paylod) 
+        v
       ];
     case 'UPDATE_NODE':
       return state.map(node => {

--- a/dag.js
+++ b/dag.js
@@ -157,7 +157,7 @@ export class DAG extends Component {
   }
   addNode(node, props) {
     let {type, label} = node,
-        f = Object.assign({}, props, {
+        nodeProps = Object.assign({}, props, {
           type, 
           label,
           id : type + Date.now().toString().slice(8)	  
@@ -165,7 +165,7 @@ export class DAG extends Component {
         
     this.store.dispatch({
       type: 'ADD-NODE',
-      payload: f
+      payload: nodeProps
     });
   }
   cleanUpGraph() {

--- a/dag.js
+++ b/dag.js
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom';
 import {configureStore} from './dag-store';
 import {getSettings} from './dag-settings';
 import uuid from 'node-uuid';
+import jsPlumb from 'jsPlumb';
+
 
 import NodesList from './components/NodesList/NodesList';
 
 require('./styles/dag.less');
-var jsPlumb = require('jsPlumb').jsPlumb;
 
 var classnames = require('classname');
 

--- a/dag.js
+++ b/dag.js
@@ -154,15 +154,17 @@ export class DAG extends Component {
       }
     }, 600);
   }
-  addNode(node) {
-    let {type, label} = node;
+  addNode(node, props) {
+    let {type, label} = node,
+	p = {
+	  type, 
+  	  label,
+          id : type + Date.now().toString().slice(8)	  
+	};
+
     this.store.dispatch({
       type: 'ADD-NODE',
-      payload: {
-        type,
-        label,
-        id: type + Date.now().toString().slice(8)
-      }
+      payload: Object.assign({}, p, props);
     });
   }
   cleanUpGraph() {

--- a/dag.js
+++ b/dag.js
@@ -157,15 +157,15 @@ export class DAG extends Component {
   }
   addNode(node, props) {
     let {type, label} = node,
-	p = {
-	  type, 
-  	  label,
+        f = Object.assign({}, props, {
+          type, 
+          label,
           id : type + Date.now().toString().slice(8)	  
-	};
-
+        });
+        
     this.store.dispatch({
       type: 'ADD-NODE',
-      payload: Object.assign({}, p, props);
+      payload: f
     });
   }
   cleanUpGraph() {

--- a/package.json
+++ b/package.json
@@ -2,22 +2,24 @@
   "name": "react-dag",
   "version": "2.0.0",
   "description": "This is a base implementation of wrapping jsplumb with react + redux to be more usable in a react based environment",
-  "main": "dist/react-dag.js",
+  "main": "./dist/react-dag.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev-build": "webpack --watch -d",
+    "dev-build-watch": "webpack --watch -d",
+    "dev-build": "webpack -d",
     "prod-build": "NODE_ENV=production webpack -p",
     "lib-test-build": "NODE_ENV=libtest webpack -d"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "classname": "0.0.0",
-    "jsplumb": "sporritt/jsPlumb#2.2.0",
+    "jsplumb": "git://github.com/sporritt/jsPlumb#2.2.0",
     "lodash": "^4.13.1",
     "node-uuid": "1.4.7",
-    "react": "15.0.1",
-    "react-dom": "15.0.1",
+    "react": "15.3.2",
+    "react-dom": "15.3.2",
     "redux": "3.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
First of all, sweet library man!

I added two things in here

1) Fixed a couple build issues on my local by updating the path to the jsplumb library and also switching it from using a require to an import.  I was not able to build this on my local machine and that fixed that issue for me.

2) Added the ability to add additional properties on the nodes to pass through so that when we extract the actual DAG those custom properties are on the nodes.

Let me know if you need anything else fixed.  I am also interested in getting this on npm, if I can help in anyway by hooking up travisci to this or anything let me know.
