### PR TITLE
Implement draggable settings with the containmnent option

### DIFF
--- a/dag-settings.js
+++ b/dag-settings.js
@@ -48,7 +48,9 @@ export const sinkSettings = extend({
   anchor: [ 0.5, 1, -1, 0, -26, -43, 'sinkAnchor'],
   connectorStyle: connectorStyle
 }, commonSettings);
-
+export const DraggableSettings = {
+  containment: false
+};
 export function getSettings(isDisabled: ?boolean = false) {
   var settings: Object = {
     transformSource: {},
@@ -61,7 +63,8 @@ export function getSettings(isDisabled: ?boolean = false) {
       source: extend(sourceSettings, disabledConnectorOverlays),
       sink: extend(sinkSettings, disabledConnectorOverlays),
       transformSource: {},
-      transformSink: {}
+      transformSink: {},
+      draggable: DraggableSettings
     };
   } else {
     settings = {
@@ -70,7 +73,8 @@ export function getSettings(isDisabled: ?boolean = false) {
       source: extend(sourceSettings, connectorOverlays),
       sink: extend(sinkSettings, connectorOverlays),
       transformSource: {},
-      transformSink: {}
+      transformSink: {},
+      draggable: DraggableSettings
     };
   }
 

--- a/dag.js
+++ b/dag.js
@@ -107,6 +107,7 @@ export default class DAG extends Component {
   makeNodesDraggable() {
     let nodes = document.querySelectorAll('#dag-container .node');
     this.instance.draggable(nodes, {
+      containment: this.settings.draggable.containment,
       start: () => {
         console.log('Starting to drag');
       },


### PR DESCRIPTION
Hello,

Currently node are made draggable with default settings. This pull request allows developer to define this option in dag-settings (DraggableSettings => containment: true/false). See https://jsplumbtoolkit.com/community/doc/dragging.html (Drag Containment). 

Kind regards,
Sam